### PR TITLE
fix: Resolve error can't access toString of null in Zmanim inputs

### DIFF
--- a/src/lib/js/input.js
+++ b/src/lib/js/input.js
@@ -165,7 +165,7 @@ async function getValidDerivations(search, results) {
 	// determine disambiguations and skip invalid derivations
 	for (const derivation of results) {
 		derivation.disambiguation = Object.values(derivation)
-			.map((value) => (value.toString() === '[object Object]' ? JSON.stringify(value) : value.toString()))
+			.map((value) => (`${value}` === '[object Object]' ? JSON.stringify(value) : `${value}`))
 			.join(', ');
 		derivation.disambiguationScore = 0;
 		if (derivation.function === 'unitConversionQuery') {


### PR DESCRIPTION
## Summary

<!-- Please include a summary of the change and which issue is fixed. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [ ] Added or updated test cases to test new features
