### PR TITLE
fix: Prefill calculators when q is set

### DIFF
--- a/src/routes/tools/birkas-hachama/+page.svelte
+++ b/src/routes/tools/birkas-hachama/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import BirkasHachamaExamples from '../../input/examples/BirkasHachamaExamples.svelte';
 
@@ -9,6 +10,9 @@
 	$: clickFunction = inputCalculator?.setSections;
 
 	const description = 'Calculate when Birkas Hachama will occur and when it has occurred in the past.';
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? 'When is the next Birkas Hachama?';
 </script>
 
 <svelte:head>
@@ -21,7 +25,7 @@
 
 	<p class="center">{description}</p>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="When is the next Birkas Hachama?" />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<BirkasHachamaExamples {clickFunction} />

--- a/src/routes/tools/daily-learning/+page.svelte
+++ b/src/routes/tools/daily-learning/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import dayjs from 'dayjs';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import DailyLearningExamples from '../../input/examples/DailyLearningExamples.svelte';
@@ -12,6 +13,9 @@
 	const today = dayjs().format('MMMM D, YYYY');
 
 	const description = 'Calculate the Daf Yomi, Nach Yomi, Yerushalmi Yomi, Chofetz Chaim, Daily Rambam, Shemirat HaLashon, Daily Psalms, and Weekly Daf for any date.';
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? `What is the Daf Yomi for ${today}?`;
 </script>
 
 <svelte:head>
@@ -24,7 +28,7 @@
 
 	<p class="center">{description}</p>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="What is the Daf Yomi for {today}?" />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<DailyLearningExamples {clickFunction} />

--- a/src/routes/tools/gematria-match/+page.svelte
+++ b/src/routes/tools/gematria-match/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import GematriaMatchExamples from '../../input/examples/GematriaMatchExamples.svelte';
 
@@ -9,6 +10,9 @@
 	$: clickFunction = inputCalculator?.setSections;
 
 	const description = 'Enter two words and the gematria of each will be calculated according to 25 methods and a list of methods where the words have an equivalent value will be displayed.';
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? 'Gematria equivalences for תורה and משנה.';
 </script>
 
 <svelte:head>
@@ -21,7 +25,7 @@
 
 	<p class="center">{description}</p>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="Gematria equivalences for תורה and משנה." />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<GematriaMatchExamples {clickFunction} />

--- a/src/routes/tools/hebrew-zodiac-signs/+page.svelte
+++ b/src/routes/tools/hebrew-zodiac-signs/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import dayjs from 'dayjs';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import ZodiacExamples from '../../input/examples/ZodiacExamples.svelte';
@@ -13,6 +14,9 @@
 
 	const description =
 		'Enter your birthday and specify if you were born after sunset. Your full Hebrew birthday and your Hebrew astrology zodiac sign will be displayed (in Hebrew, transliterated Hebrew, and the Latin equivalent).';
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? `What is the zodiac sign for ${today}?`;
 </script>
 
 <svelte:head>
@@ -25,7 +29,7 @@
 
 	<p class="center">{description}</p>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="What is the zodiac sign for {today}?" />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<ZodiacExamples {clickFunction} />

--- a/src/routes/tools/jewish-holidays/+page.svelte
+++ b/src/routes/tools/jewish-holidays/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import JewishHolidayExamples from '../../input/examples/JewishHolidayExamples.svelte';
 
@@ -9,6 +10,9 @@
 	$: clickFunction = inputCalculator?.setSections;
 
 	const description = 'Enter a Gregorian or Hebrew Year below to display the dates for Jewish holidays for the given year, or enter a Jewish holiday to find out when it will occur in a given year.';
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? 'Upcoming Jewish holidays';
 </script>
 
 <svelte:head>
@@ -21,7 +25,7 @@
 
 	<p class="center">{description}</p>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="Upcoming Jewish holidays" />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<JewishHolidayExamples {clickFunction} />

--- a/src/routes/tools/sefiras-haomer/+page.svelte
+++ b/src/routes/tools/sefiras-haomer/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import dayjs from 'dayjs';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import SefirasHaOmerExamples from '../../input/examples/SefirasHaOmerExamples.svelte';
@@ -50,6 +51,9 @@
 		}
 		popup.document.write(html);
 	}
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? `What is the Sefiras HaOmer for ${today}?`;
 </script>
 
 <svelte:head>
@@ -67,7 +71,7 @@
 		<button class="sefirah-link" style="background-image: url({addIcal})" on:click={openAddToICal}></button>
 	</div>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="What is the Sefiras HaOmer for {today}?" />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<SefirasHaOmerExamples {clickFunction} />

--- a/src/routes/tools/shmita/+page.svelte
+++ b/src/routes/tools/shmita/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import ShmitaExamples from '../../input/examples/ShmitaExamples.svelte';
 
@@ -9,6 +10,9 @@
 	$: clickFunction = inputCalculator?.setSections;
 
 	const description = 'Calculate when Shmita will occur and when it has occurred in the past.';
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? 'When is the next Shmita year?';
 </script>
 
 <svelte:head>
@@ -21,7 +25,7 @@
 
 	<p class="center">{description}</p>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="When is the next Shmita year?" />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<ShmitaExamples {clickFunction} />

--- a/src/routes/tools/zmanim/+page.svelte
+++ b/src/routes/tools/zmanim/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { page } from '$app/stores';
 	import dayjs from 'dayjs';
 	import InputCalculator from '../../input/InputCalculator.svelte';
 	import ZmanimExamples from '../../input/examples/ZmanimExamples.svelte';
@@ -12,6 +13,9 @@
 	const description = 'Calculate the halachic times of the day for any date and location.';
 
 	const today = dayjs().format('MMMM D, YYYY');
+
+	/** @type {string} The current query in the input box (not yet submitted) */
+	export let queryInput = $page.url.searchParams.get('q') ?? `Zmanim for Denver on ${today}`;
 </script>
 
 <svelte:head>
@@ -24,7 +28,7 @@
 
 	<p class="center">{description}</p>
 
-	<InputCalculator bind:this={inputCalculator} queryInput="Zmanim for Denver on {today}" />
+	<InputCalculator bind:this={inputCalculator} {queryInput} />
 
 	<div class="examples">
 		<ZmanimExamples {clickFunction} />


### PR DESCRIPTION
## Summary

Pre-fill the input box on input-based calculator pages when `q` is set

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [ ] Added or updated test cases to test new features
