### PR TITLE
fix(molad): time of day error in certain timezones

### DIFF
--- a/src/lib/js/molad.js
+++ b/src/lib/js/molad.js
@@ -207,7 +207,7 @@ export function formatMoladHebrewDate(molad, chalakim, is24Hour) {
  */
 export function formatMoladDayOfWeek(molad, chalakim, is24Hour) {
 	// Determine if the molad was after sunset in Jerusalem
-	const zmanim = new Zmanim(new Date(molad.format("YYYY-MM-DD")), 31.77759, 35.23564);
+	const zmanim = new Zmanim(new Date(molad.format('YYYY-MM-DD')), 31.77759, 35.23564);
 	// adjust for timezone - make all times in UTC even though they are really Jerusalem time
 	const sunset = dayjs.utc(Zmanim.formatISOWithTimeZone('Asia/Jerusalem', zmanim.sunset()).replace(/\+.+$/, '')); // remove timezone offset to compare as UTC
 

--- a/src/lib/js/molad.js
+++ b/src/lib/js/molad.js
@@ -207,7 +207,7 @@ export function formatMoladHebrewDate(molad, chalakim, is24Hour) {
  */
 export function formatMoladDayOfWeek(molad, chalakim, is24Hour) {
 	// Determine if the molad was after sunset in Jerusalem
-	const zmanim = new Zmanim(molad.toDate(), 31.77759, 35.23564);
+	const zmanim = new Zmanim(new Date(molad.format("YYYY-MM-DD")), 31.77759, 35.23564);
 	// adjust for timezone - make all times in UTC even though they are really Jerusalem time
 	const sunset = dayjs.utc(Zmanim.formatISOWithTimeZone('Asia/Jerusalem', zmanim.sunset()).replace(/\+.+$/, '')); // remove timezone offset to compare as UTC
 


### PR DESCRIPTION
## Summary

Sometimes the day zmanim get calculated for was the next day instead of current day which would cause "afternoon" to be displayed instead of "evening"

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [ ] Added or updated test cases to test new features
