### PR TITLE
fix: resolve text and value error

### DIFF
--- a/src/routes/api/gematriasearch/+server.js
+++ b/src/routes/api/gematriasearch/+server.js
@@ -10,7 +10,7 @@ export async function GET({ url }) {
 
 	try {
 		if (text !== null) {
-			if (value !== null) {
+			if (value !== 0) {
 				throw new Error("Unexpected 'text' and 'value' parameters. Only one of these parameters should be provided.");
 			}
 			value = calculateGematria({ text }).standard;


### PR DESCRIPTION
Resolves     "error": "Unexpected 'text' and 'value' parameters. Only one of these parameters should be provided."
when text provided